### PR TITLE
feat: Seek firmware from path specified in kernel parameter path filesystem

### DIFF
--- a/cmd/remoteproc-simulator/main.go
+++ b/cmd/remoteproc-simulator/main.go
@@ -88,7 +88,7 @@ Example usage:
 
 	rootCmd.Flags().UintVar(&index, "index", 0, "is the N in /sys/class/remoteproc/remoteprocN/.../ (default 0)")
 	rootCmd.Flags().StringVar(&name, "name", "dsp0", "remote processor name written to /sys/class/remoteproc/.../name")
-	rootCmd.Flags().StringVar(&rootDir, "root-dir", "", "location where /sys and /lib will be created")
+	rootCmd.Flags().StringVar(&rootDir, "root-dir", "", "location where /sys will be created")
 	rootCmd.Flags().BoolVar(&showVersion, "version", false, "show version information")
 
 	if err := rootCmd.Execute(); err != nil {

--- a/e2e/boostrapping_test.go
+++ b/e2e/boostrapping_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -50,7 +51,8 @@ func TestBootstrapping(t *testing.T) {
 
 		runSimulator(t, "--root-dir", root, "--index", "99")
 
-		firmwareDir := filepath.Join(root, "lib", "firmware")
-		assert.DirExists(t, firmwareDir)
+		firmwareDir, err := os.ReadFile(filepath.Join(root, "sys", "module", "firmware_class", "parameters", "path"))
+		assert.NoError(t, err)
+		assert.DirExists(t, string(firmwareDir))
 	})
 }

--- a/e2e/boostrapping_test.go
+++ b/e2e/boostrapping_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -53,6 +54,6 @@ func TestBootstrapping(t *testing.T) {
 
 		firmwareDir, err := os.ReadFile(filepath.Join(root, "sys", "module", "firmware_class", "parameters", "path"))
 		assert.NoError(t, err)
-		assert.DirExists(t, string(firmwareDir))
+		assert.DirExists(t, strings.TrimSpace(string(firmwareDir)))
 	})
 }

--- a/e2e/running_firmware_test.go
+++ b/e2e/running_firmware_test.go
@@ -26,7 +26,7 @@ func TestRunningFirmware(t *testing.T) {
 		requireState(t, instanceDir, "offline")
 	})
 
-	t.Run("firmware file must exist in folder indicated inside /sys/module/firmware_class/parameters/path", func(t *testing.T) {
+	t.Run("firmware file must exist in folder indicated inside <fake-root>/sys/module/firmware_class/parameters/path", func(t *testing.T) {
 		root := t.TempDir()
 		runSimulator(t, "--root-dir", root, "--index", "0")
 		instanceDir := filepath.Join(root, "sys", "class", "remoteproc", "remoteproc0")

--- a/e2e/running_firmware_test.go
+++ b/e2e/running_firmware_test.go
@@ -25,7 +25,7 @@ func TestRunningFirmware(t *testing.T) {
 		requireState(t, instanceDir, "offline")
 	})
 
-	t.Run("firmware file must exist in /lib/firmware", func(t *testing.T) {
+	t.Run("firmware file must exist in folder indicated inside /sys/module/firmware_class/parameters/path", func(t *testing.T) {
 		root := t.TempDir()
 		runSimulator(t, "--root-dir", root, "--index", "0")
 		instanceDir := filepath.Join(root, "sys", "class", "remoteproc", "remoteproc0")
@@ -38,7 +38,10 @@ func TestRunningFirmware(t *testing.T) {
 }
 
 func createFirmwareFile(t *testing.T, root, firmwareName string) {
-	firmwarePath := filepath.Join(root, "lib", "firmware", firmwareName)
+	firmwareDirPath, err := os.ReadFile(filepath.Join(root, "sys", "module", "firmware_class", "parameters", "path"))
+	require.NoError(t, err)
+	os.MkdirAll(string(firmwareDirPath), 0755)
+	firmwarePath := filepath.Join(string(firmwareDirPath), firmwareName)
 	require.NoError(t, writeFile(firmwarePath, ""))
 }
 

--- a/e2e/running_firmware_test.go
+++ b/e2e/running_firmware_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -40,8 +41,10 @@ func TestRunningFirmware(t *testing.T) {
 func createFirmwareFile(t *testing.T, root, firmwareName string) {
 	firmwareDirPath, err := os.ReadFile(filepath.Join(root, "sys", "module", "firmware_class", "parameters", "path"))
 	require.NoError(t, err)
-	os.MkdirAll(string(firmwareDirPath), 0755)
-	firmwarePath := filepath.Join(string(firmwareDirPath), firmwareName)
+	firmwareDirPathStr := strings.TrimSpace(string(firmwareDirPath))
+	err = os.MkdirAll(firmwareDirPathStr, 0755)
+	require.NoError(t, err)
+	firmwarePath := filepath.Join(firmwareDirPathStr, firmwareName)
 	require.NoError(t, writeFile(firmwarePath, ""))
 }
 

--- a/pkg/simulator/filesystem.go
+++ b/pkg/simulator/filesystem.go
@@ -92,7 +92,7 @@ func (fs *FileSystemManager) Cleanup() error {
 }
 
 func mkfile(path string, perm os.FileMode) (string, error) {
-	folder, err := mkdirAll(filepath.Dir(path), perm)
+	dir, err := mkdirAll(filepath.Dir(path), perm)
 	if err != nil {
 		return "", err
 	}
@@ -101,7 +101,7 @@ func mkfile(path string, perm os.FileMode) (string, error) {
 		return "", err
 	}
 	defer file.Close()
-	return folder, nil
+	return dir, nil
 }
 
 func mkdirAll(path string, perm os.FileMode) (string, error) {

--- a/pkg/simulator/filesystem.go
+++ b/pkg/simulator/filesystem.go
@@ -32,13 +32,13 @@ func (fs *FileSystemManager) BootstrapDirectories() error {
 		fs.createdDirs = append(fs.createdDirs, createdInstancePath)
 	}
 
-	createdParentDir, err := mkfile(fs.firmwareDirPathFile, 0755)
+	createdFirmwareDirSpecPath, err := mkfile(fs.firmwareDirPathFile, 0755)
 	if err != nil {
 		fs.Cleanup()
 		return fmt.Errorf("failed to create firmware path directory: %w", err)
 	}
-	if createdParentDir != "" {
-		fs.createdDirs = append(fs.createdDirs, createdParentDir)
+	if createdFirmwareDirSpecPath != "" {
+		fs.createdDirs = append(fs.createdDirs, createdFirmwareDirSpecPath)
 	}
 
 	if err := os.WriteFile(fs.firmwareDirPathFile, []byte(fs.firmwareDir), 0644); err != nil {

--- a/pkg/simulator/filesystem.go
+++ b/pkg/simulator/filesystem.go
@@ -32,12 +32,14 @@ func (fs *FileSystemManager) BootstrapDirectories() error {
 		fs.createdDirs = append(fs.createdDirs, createdInstancePath)
 	}
 
-	createdFirmwareDirPathFileFolder, err := mkfile(fs.firmwareDirPathFile, 0755)
+	createdParentDir, err := mkfile(fs.firmwareDirPathFile, 0755)
 	if err != nil {
 		fs.Cleanup()
 		return fmt.Errorf("failed to create firmware path directory: %w", err)
 	}
-	fs.createdDirs = append(fs.createdDirs, createdFirmwareDirPathFileFolder)
+	if createdParentDir != "" {
+		fs.createdDirs = append(fs.createdDirs, createdParentDir)
+	}
 
 	if err := os.WriteFile(fs.firmwareDirPathFile, []byte(fs.firmwareDir), 0644); err != nil {
 		fs.Cleanup()
@@ -49,7 +51,9 @@ func (fs *FileSystemManager) BootstrapDirectories() error {
 		fs.Cleanup()
 		return fmt.Errorf("failed to create firmware directory: %w", err)
 	}
-	fs.createdDirs = append(fs.createdDirs, createdFirmwareDir)
+	if createdFirmwareDir != "" {
+		fs.createdDirs = append(fs.createdDirs, createdFirmwareDir)
+	}
 
 	return nil
 }

--- a/pkg/simulator/filesystem.go
+++ b/pkg/simulator/filesystem.go
@@ -101,7 +101,12 @@ func mkfile(path string, perm os.FileMode) (string, error) {
 		return "", err
 	}
 	defer file.Close()
-	return dir, nil
+	if dir == "" {
+		return path, nil
+	} else {
+		return dir, nil
+	}
+
 }
 
 func mkdirAll(path string, perm os.FileMode) (string, error) {


### PR DESCRIPTION
<!-- PR title should be formatted using conventional commits -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: A very fancy feature -->

## Changes

<!-- List the changes this PR introduces -->

- Documentation change on root-dir so that /lib/firmware is not assumed by the users
- Test changes to check the firmware directory based on what is inside `/sys/module/firmware_class/parameters/path`
- Change e2e test to create firmware based on readings of `/sys/module/firmware_class/parameters/path`
- Update the filesystem manager to keep the `/sys/module/firmware_class/parameters/path` and the actual firmware path
- Verify firmware's existence based on the path pointed by `/sys/module/firmware_class/parameters/path`
- Add helper file mkfile() which would make all the parent folder of a path and make a file with the basename of the path

## Checklist

<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [X] 🤖 This change is covered by tests as required.
- [ ] 🤹 All required manual testing has been performed.
- [X] 📖 All documentation updates are complete.
