### PR TITLE
feat: Support remoteproc-like path lookup (custom path, then `/lib/firmware`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,22 @@ Inspect remote processor name:
 cat /tmp/fake-root/sys/class/remoteproc/remoteproc0/name
 ```
 
+Specify custom firmware load path:
+
+```bash
+# Set custom load path
+echo /tmp > /tmp/fake-root/sys/module/firmware_class/parameters/path
+
+# Prepare firmware file in custom path
+touch /tmp/hi_universe.elf
+
+# Set firmware
+echo hi_universe.elf > /tmp/fake-root/sys/class/remoteproc/remoteproc0/firmware
+
+# Start the remote processor
+echo start > /tmp/fake-root/sys/class/remoteproc/remoteproc0/state
+```
+
 ## Installation from Releases
 
 The release binaries are unsigned. On macOS, you'll need to remove the quarantine attribute before running:

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Control the simulated remote processor via sysfs:
 
 ```bash
 # Prepare firmware file
-touch /tmp/fake-root/lib/firmware/hello_world.elf
+touch /tmp/fake-root/lib/firmware/hello-world.elf
 
 # Set firmware
-echo hello_world.elf > /tmp/fake-root/sys/class/remoteproc/remoteproc0/firmware
+echo hello-world.elf > /tmp/fake-root/sys/class/remoteproc/remoteproc0/firmware
 
 # Start the remote processor
 echo start > /tmp/fake-root/sys/class/remoteproc/remoteproc0/state
@@ -54,10 +54,10 @@ Specify custom firmware load path:
 echo /tmp > /tmp/fake-root/sys/module/firmware_class/parameters/path
 
 # Prepare firmware file in custom path
-touch /tmp/hi_universe.elf
+touch /tmp/hi-universe.elf
 
 # Set firmware
-echo hi_universe.elf > /tmp/fake-root/sys/class/remoteproc/remoteproc0/firmware
+echo hi-universe.elf > /tmp/fake-root/sys/class/remoteproc/remoteproc0/firmware
 
 # Start the remote processor
 echo start > /tmp/fake-root/sys/class/remoteproc/remoteproc0/state

--- a/cmd/remoteproc-simulator/main.go
+++ b/cmd/remoteproc-simulator/main.go
@@ -88,7 +88,7 @@ Example usage:
 
 	rootCmd.Flags().UintVar(&index, "index", 0, "is the N in /sys/class/remoteproc/remoteprocN/.../ (default 0)")
 	rootCmd.Flags().StringVar(&name, "name", "dsp0", "remote processor name written to /sys/class/remoteproc/.../name")
-	rootCmd.Flags().StringVar(&rootDir, "root-dir", "", "location where /sys will be created")
+	rootCmd.Flags().StringVar(&rootDir, "root-dir", "", "location where /sys and /lib will be created")
 	rootCmd.Flags().BoolVar(&showVersion, "version", false, "show version information")
 
 	if err := rootCmd.Execute(); err != nil {

--- a/e2e/boostrapping_test.go
+++ b/e2e/boostrapping_test.go
@@ -45,6 +45,15 @@ func TestBootstrapping(t *testing.T) {
 		assert.DirExists(t, instanceDir)
 	})
 
+	t.Run("default firmware directory is created", func(t *testing.T) {
+		root := t.TempDir()
+
+		runSimulator(t, "--root-dir", root, "--index", "99")
+
+		pathFile := filepath.Join(root, "lib", "firmware")
+		assert.DirExists(t, pathFile)
+	})
+
 	t.Run("file used to customize firmware search path is created", func(t *testing.T) {
 		root := t.TempDir()
 

--- a/e2e/boostrapping_test.go
+++ b/e2e/boostrapping_test.go
@@ -47,7 +47,7 @@ func TestBootstrapping(t *testing.T) {
 		assert.DirExists(t, instanceDir)
 	})
 
-	t.Run("firmware directory is created", func(t *testing.T) {
+	t.Run("file used to customize firmware search path is created", func(t *testing.T) {
 		root := t.TempDir()
 
 		runSimulator(t, "--root-dir", root, "--index", "99")

--- a/e2e/boostrapping_test.go
+++ b/e2e/boostrapping_test.go
@@ -1,9 +1,7 @@
 package e2e
 
 import (
-	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -52,8 +50,7 @@ func TestBootstrapping(t *testing.T) {
 
 		runSimulator(t, "--root-dir", root, "--index", "99")
 
-		firmwareDir, err := os.ReadFile(filepath.Join(root, "sys", "module", "firmware_class", "parameters", "path"))
-		assert.NoError(t, err)
-		assert.DirExists(t, strings.TrimSpace(string(firmwareDir)))
+		pathFile := filepath.Join(root, "sys", "module", "firmware_class", "parameters", "path")
+		assert.FileExists(t, pathFile)
 	})
 }

--- a/pkg/simulator/filesystem.go
+++ b/pkg/simulator/filesystem.go
@@ -7,19 +7,19 @@ import (
 )
 
 type FileSystemManager struct {
-	instanceDir         string
-	firmwareDirPathFile string
-	firmwareDir         string
-	createdDirs         []string
+	instanceDir            string
+	firmwareSearchPathFile string
+	firmwareDir            string
+	createdDirs            []string
 }
 
 func NewFileSystemManager(rootDir string, index uint) *FileSystemManager {
 	instanceName := fmt.Sprintf("remoteproc%d", index)
 	return &FileSystemManager{
-		instanceDir:         filepath.Join(rootDir, "sys", "class", "remoteproc", instanceName),
-		firmwareDirPathFile: filepath.Join(rootDir, "sys", "module", "firmware_class", "parameters", "path"),
-		firmwareDir:         filepath.Join(rootDir, "firmware"),
-		createdDirs:         []string{},
+		instanceDir:            filepath.Join(rootDir, "sys", "class", "remoteproc", instanceName),
+		firmwareSearchPathFile: filepath.Join(rootDir, "sys", "module", "firmware_class", "parameters", "path"),
+		firmwareDir:            filepath.Join(rootDir, "firmware"),
+		createdDirs:            []string{},
 	}
 }
 
@@ -32,7 +32,7 @@ func (fs *FileSystemManager) BootstrapDirectories() error {
 		fs.createdDirs = append(fs.createdDirs, createdInstancePath)
 	}
 
-	createdFirmwareDirSpecPath, err := mkfile(fs.firmwareDirPathFile, 0755)
+	createdFirmwareDirSpecPath, err := mkfile(fs.firmwareSearchPathFile, 0755)
 	if err != nil {
 		fs.Cleanup()
 		return fmt.Errorf("failed to create firmware path directory: %w", err)
@@ -41,7 +41,7 @@ func (fs *FileSystemManager) BootstrapDirectories() error {
 		fs.createdDirs = append(fs.createdDirs, createdFirmwareDirSpecPath)
 	}
 
-	if err := os.WriteFile(fs.firmwareDirPathFile, []byte(fs.firmwareDir), 0644); err != nil {
+	if err := os.WriteFile(fs.firmwareSearchPathFile, []byte(fs.firmwareDir), 0644); err != nil {
 		fs.Cleanup()
 		return fmt.Errorf("failed to write firmware path file: %w", err)
 	}

--- a/pkg/simulator/remoteproc.go
+++ b/pkg/simulator/remoteproc.go
@@ -163,8 +163,8 @@ func (r *Remoteproc) handleStateChange(value string) {
 			return
 		}
 
-		if !r.fs.FirmwareExists(r.firmware) {
-			log.Printf("Cannot start: firmware file not found in %s directory", r.fs.FirmwareDir())
+		if err := r.fs.CheckFirmwareExists(r.firmware); err != nil {
+			log.Printf("Cannot start: %s", err)
 			r.setState(r.state)
 			return
 		}


### PR DESCRIPTION
<!-- PR title should be formatted using conventional commits -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: A very fancy feature -->

## Changes

<!-- List the changes this PR introduces -->

- Builds on top of https://github.com/arm/remoteproc-simulator/pull/2
- Restore the default "last resort" `/lib/firmware` lookup if custom path is not specified or firmware isn't found in custom path
   - This is more accurate simulation of how the [path lookup works in remoteproc](https://www.kernel.org/doc/html/v4.18/driver-api/firmware/fw_search_path.html)
       - Look in custom path first
       - Then look in `/lib/firmware`

## Checklist

<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [x] 🤖 This change is covered by tests as required.
- [x] 🤹 All required manual testing has been performed.
- [x] 📖 All documentation updates are complete.
